### PR TITLE
Add cross-env module to templates (fix 1)

### DIFF
--- a/src/templates/stickyboard-mysql/package-lock.json
+++ b/src/templates/stickyboard-mysql/package-lock.json
@@ -4324,6 +4324,52 @@
                 "moment-timezone": "^0.5.x"
             }
         },
+        "cross-env": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+            "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+            "requires": {
+                "cross-spawn": "^7.0.1"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+                    "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+                    "requires": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                    }
+                },
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
         "cross-fetch": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
@@ -7859,8 +7905,7 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "3.0.1",

--- a/src/templates/stickyboard-mysql/package.json
+++ b/src/templates/stickyboard-mysql/package.json
@@ -8,12 +8,12 @@
     "private": true,
     "author": "soaple",
     "scripts": {
-        "watch": "NODE_ENV=development npm run watch-app-dev",
+        "watch": "cross-env NODE_ENV=development npm run watch-app-dev",
         "watch-app-dev": "WEBPACK_DEV_SERVER_MODE=true webpack-dev-server --progress --config=webpack.config.js",
-        "build": "NODE_ENV=production webpack --config webpack.config.js",
+        "build": "cross-env NODE_ENV=production webpack --config webpack.config.js",
         "start": "pm2-runtime start ecosystem.config.js --env production --name stickyboard",
-        "dev": "NODE_ENV=development NODE_PATH=./src WEBPACK_DEV_SERVER_MODE=true node app.js",
-        "production": "NODE_ENV=production NODE_PATH=./src node app.js"
+        "dev": "cross-env NODE_ENV=development NODE_PATH=./src WEBPACK_DEV_SERVER_MODE=true node app.js",
+        "production": "cross-env NODE_ENV=production NODE_PATH=./src node app.js"
     },
     "dependencies": {
         "@loadable/component": "^5.12.0",
@@ -27,6 +27,7 @@
         "body-parser": "^1.19.0",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
+        "cross-env": "^7.0.2",
         "dotenv": "^8.2.0",
         "ejs": "^2.7.4",
         "express": "^4.17.1",

--- a/src/templates/stickyboard-simple/package-lock.json
+++ b/src/templates/stickyboard-simple/package-lock.json
@@ -3604,6 +3604,52 @@
                 "moment-timezone": "^0.5.x"
             }
         },
+        "cross-env": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+            "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+            "requires": {
+                "cross-spawn": "^7.0.1"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+                    "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+                    "requires": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                    }
+                },
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
         "cross-spawn": {
             "version": "6.0.5",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -6312,8 +6358,7 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "3.0.1",

--- a/src/templates/stickyboard-simple/package.json
+++ b/src/templates/stickyboard-simple/package.json
@@ -8,12 +8,12 @@
     "private": true,
     "author": "soaple",
     "scripts": {
-        "watch": "NODE_ENV=development npm run watch-app-dev",
+        "watch": "cross-env NODE_ENV=development npm run watch-app-dev",
         "watch-app-dev": "WEBPACK_DEV_SERVER_MODE=true webpack-dev-server --progress --config=webpack.config.js",
-        "build": "NODE_ENV=production webpack --config webpack.config.js",
+        "build": "cross-env NODE_ENV=production webpack --config webpack.config.js",
         "start": "pm2-runtime start ecosystem.config.js --env production --name stickyboard",
-        "dev": "NODE_ENV=development NODE_PATH=./src WEBPACK_DEV_SERVER_MODE=true node app.js",
-        "production": "NODE_ENV=production NODE_PATH=./src node app.js"
+        "dev": "cross-env NODE_ENV=development NODE_PATH=./src WEBPACK_DEV_SERVER_MODE=true node app.js",
+        "production": "cross-env NODE_ENV=production NODE_PATH=./src node app.js"
     },
     "dependencies": {
         "@loadable/component": "^5.12.0",
@@ -25,6 +25,7 @@
         "body-parser": "^1.19.0",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
+        "cross-env": "^7.0.2",
         "dotenv": "^8.2.0",
         "ejs": "^2.7.4",
         "express": "^4.17.1",


### PR DESCRIPTION
fix #1 

## description

Add `cross-env` module to templates (simple, mysql)
So, Windows OS users can also use this template.
